### PR TITLE
NMS: Fix bit-mask calculation as last argument of PacketPlayOutMapChunk constructor

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,6 @@
 name: LightAPI
 main: ru.beykerykt.lightapi.LightAPI
-version: 3.2.4
+version: 3.2.4-X.12.0
 description: Bukkit Library for create invisible light source
 author: BeYkeRYkt
 commands:

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_10_R1.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_10_R1.java
@@ -104,7 +104,10 @@ public class CraftBukkit_v1_10_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 65534); // ?
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// Use 0x1ffff instead 0xffff because of little bug in PacketPlayOutMapChunk constructor.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 0x1ffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -122,7 +125,10 @@ public class CraftBukkit_v1_10_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_11_R1.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_11_R1.java
@@ -104,7 +104,10 @@ public class CraftBukkit_v1_11_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 65534); // ?
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// Use 0x1ffff instead 0xffff because of little bug in PacketPlayOutMapChunk constructor.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 0x1ffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -122,7 +125,10 @@ public class CraftBukkit_v1_11_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_12_R1.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_12_R1.java
@@ -75,7 +75,10 @@ public class CraftBukkit_v1_12_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 65534); // ?
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// Use 0x1ffff instead 0xffff because of little bug in PacketPlayOutMapChunk constructor.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 0x1ffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -93,7 +96,10 @@ public class CraftBukkit_v1_12_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_8_R3.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_8_R3.java
@@ -104,7 +104,9 @@ public class CraftBukkit_v1_8_R3 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 65535);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 0xffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -122,7 +124,10 @@ public class CraftBukkit_v1_8_R3 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_9_R1.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_9_R1.java
@@ -104,7 +104,9 @@ public class CraftBukkit_v1_9_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 65535); // ?
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 0xffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -122,7 +124,10 @@ public class CraftBukkit_v1_9_R1 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_9_R2.java
+++ b/src/ru/beykerykt/lightapi/server/nms/craftbukkit/CraftBukkit_v1_9_R2.java
@@ -104,7 +104,10 @@ public class CraftBukkit_v1_9_R2 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 65534); // ?
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// Use 0x1ffff instead 0xffff because of little bug in PacketPlayOutMapChunk constructor.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, 0x1ffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -122,7 +125,10 @@ public class CraftBukkit_v1_9_R2 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}

--- a/src/ru/beykerykt/lightapi/server/nms/paperspigot/PaperSpigot_v1_8_R3.java
+++ b/src/ru/beykerykt/lightapi/server/nms/paperspigot/PaperSpigot_v1_8_R3.java
@@ -108,7 +108,9 @@ public class PaperSpigot_v1_8_R3 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 65535);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, 0xffff);
 			human.playerConnection.sendPacket(packet);
 		}
 	}
@@ -126,7 +128,10 @@ public class PaperSpigot_v1_8_R3 implements INMSHandler {
 		EntityPlayer human = ((CraftPlayer) player).getHandle();
 		Chunk pChunk = human.world.getChunkAtWorldCoords(human.getChunkCoordinates());
 		if (distanceToSquared(pChunk, chunk) < 5 * 5) {
-			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (16 * 16 * y) - 1);
+			// Last argument is bit-mask what chunk sections to update. Only lower 16 bits are used.
+			// There are 16 sections in chunk. Each section height=16. So, y-coordinate varies from 0 to 255.
+			// We know that max light=15 (15 blocks). So, it is enough to update only 3 sections: y\16-1, y\16, y\16+1
+			PacketPlayOutMapChunk packet = new PacketPlayOutMapChunk(chunk, false, (7 << (y >> 4)) >> 1);
 			human.playerConnection.sendPacket(packet);
 		}
 	}


### PR DESCRIPTION
Last parameter in PacketPlayOutMapChunk is bit mask.  It shows what chunk sections client have to update. There are 16 sections in chunk. Each section height=16. Y-coordinate varies from 0 to 255.
We know that max light=15. The value decreases for 15 blocks down and up. So, It is enough to update section with light, one section below and one section above.
mask = (7<<(y>>4))>>1
Don't worry if one bit will be in 16-th position. Only lower 16 bits in mask are used in PacketPlayOutMapChunk. I have checked it. Also, in versions 1_9_R2 and later there is strange behavior in class PacketPlayOutMapChunk: flag = mask == 0xffff. I don't know is this a bug or not, but we can't pass value 0xffff because of all entities in chank are dissapeared on client. So, I decided to use 0x1ffff instead of 0xffff,

I don't know the reason why you do not put the release on spigot plugin main page.
This is a very useful plugin and people need it.
The last commit I have built and posted here: [https://www.spigotmc.org/resources/lightapi-temporary-fork-3-2-4-1-12.48247/](url). If you are not going to make new release, then I can also do it on my page.